### PR TITLE
Add missing android bluetooth related permissions.

### DIFF
--- a/www/permissions-dummy.js
+++ b/www/permissions-dummy.js
@@ -33,7 +33,10 @@ function Permissions() {
     this.BIND_WALLPAPER = 'android.permission.BIND_WALLPAPER';
     this.BLUETOOTH = 'android.permission.BLUETOOTH';
     this.BLUETOOTH_ADMIN = 'android.permission.BLUETOOTH_ADMIN';
+    this.BLUETOOTH_ADVERTISE = "android.permission.BLUETOOTH_ADVERTISE";
+    this.BLUETOOTH_CONNECT = 'android.permission.BLUETOOTH_CONNECT';
     this.BLUETOOTH_PRIVILEGED = 'android.permission.BLUETOOTH_PRIVILEGED';
+    this.BLUETOOTH_SCAN = "android.permission.BLUETOOTH_SCAN";
     this.BODY_SENSORS = 'android.permission.BODY_SENSORS';
     this.BRICK = 'android.permission.BRICK';
     this.BROADCAST_PACKAGE_REMOVED = 'android.permission.BROADCAST_PACKAGE_REMOVED';

--- a/www/permissions-dummy.js
+++ b/www/permissions-dummy.js
@@ -33,10 +33,10 @@ function Permissions() {
     this.BIND_WALLPAPER = 'android.permission.BIND_WALLPAPER';
     this.BLUETOOTH = 'android.permission.BLUETOOTH';
     this.BLUETOOTH_ADMIN = 'android.permission.BLUETOOTH_ADMIN';
-    this.BLUETOOTH_ADVERTISE = "android.permission.BLUETOOTH_ADVERTISE";
+    this.BLUETOOTH_ADVERTISE = 'android.permission.BLUETOOTH_ADVERTISE';
     this.BLUETOOTH_CONNECT = 'android.permission.BLUETOOTH_CONNECT';
     this.BLUETOOTH_PRIVILEGED = 'android.permission.BLUETOOTH_PRIVILEGED';
-    this.BLUETOOTH_SCAN = "android.permission.BLUETOOTH_SCAN";
+    this.BLUETOOTH_SCAN = 'android.permission.BLUETOOTH_SCAN';
     this.BODY_SENSORS = 'android.permission.BODY_SENSORS';
     this.BRICK = 'android.permission.BRICK';
     this.BROADCAST_PACKAGE_REMOVED = 'android.permission.BROADCAST_PACKAGE_REMOVED';

--- a/www/permissions.js
+++ b/www/permissions.js
@@ -33,10 +33,10 @@ function Permissions() {
     this.BIND_WALLPAPER = 'android.permission.BIND_WALLPAPER';
     this.BLUETOOTH = 'android.permission.BLUETOOTH';
     this.BLUETOOTH_ADMIN = 'android.permission.BLUETOOTH_ADMIN';
-    this.BLUETOOTH_ADVERTISE = "android.permission.BLUETOOTH_ADVERTISE";
+    this.BLUETOOTH_ADVERTISE = 'android.permission.BLUETOOTH_ADVERTISE';
     this.BLUETOOTH_CONNECT = 'android.permission.BLUETOOTH_CONNECT';
     this.BLUETOOTH_PRIVILEGED = 'android.permission.BLUETOOTH_PRIVILEGED';
-    this.BLUETOOTH_SCAN = "android.permission.BLUETOOTH_SCAN";
+    this.BLUETOOTH_SCAN = 'android.permission.BLUETOOTH_SCAN';
     this.BODY_SENSORS = 'android.permission.BODY_SENSORS';
     this.BRICK = 'android.permission.BRICK';
     this.BROADCAST_PACKAGE_REMOVED = 'android.permission.BROADCAST_PACKAGE_REMOVED';


### PR DESCRIPTION
Looks like those permissions where added on the permissions.js but not on this file, after importing the current version I'm unable to use them. 

I have already tried to download this project and added those permissions, after that there are no problems using them.